### PR TITLE
Add arm64 support + refactor to use cimg orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,36 +1,26 @@
 version: 2.1
 
-workflows:
-  main:
-    jobs:
-      - build:
-          context: cimg-publishing
+orbs:
+  cimg: circleci/cimg@0.3.3
 
-jobs:
-  build:
-    docker:
-      - image: cimg/base:2022.06
-    steps:
-      - checkout
-      - setup_remote_docker:
-          version: "20.10.14"
-      - run:
-          name: "Build Docker Images"
-          command: |
-            ./build-images.sh
-            echo 'export DOCKER_PASS=$DOCKER_TOKEN' >> $BASH_ENV
-      - deploy:
-          name: "Publish Docker Images (main branch only)"
-          command: |
-            if [ "${CIRCLE_BRANCH}" == "main" ]; then
-              
-              echo $DOCKER_TOKEN | docker login -u $DOCKER_USER --password-stdin
-              
-              # an else block will be added in the future for a staging release
-              if git log -1 --pretty=%s | grep "\[release\]"; then
-                echo "Publishing cimg/aws to Docker Hub production."
-                ./push-images.sh
-              else
-                echo "Skipping publishing."
-              fi
-            fi
+workflows:
+  main-wf:
+    jobs:
+      - cimg/build-and-deploy:
+          name: "Staging"
+          docker-namespace: ccitest
+          docker-repository: aws
+          publish-branch: test
+          filters:
+            branches:
+              ignore:
+                - main
+          context: cimg-publishing
+      - cimg/build-and-deploy:
+          name: "Deploy"
+          docker-repository: aws
+          filters:
+            branches:
+              only:
+                - main
+          context: cimg-publishing

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -11,7 +11,8 @@ RUN sudo apt-get update && sudo apt-get install --yes --no-install-recommends \
 		amazon-ecr-credential-helper \
 	&& \
 	sudo rm -rf /var/lib/apt/lists/* && \
-	curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+	[[ $(uname -m) == "x86_64" ]] && ARCH="x86_64" || ARCH="aarch64" && \
+	curl "https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}.zip" -o "awscliv2.zip" && \
 	unzip awscliv2.zip && \
 	sudo ./aws/install && \
 	rm -fR aws* && \

--- a/manifest
+++ b/manifest
@@ -4,3 +4,4 @@ repository=aws
 parent=deploy
 variants=()
 namespace=cimg
+arm64=1


### PR DESCRIPTION
# Description
Add arm64 support with buildx multi arch builds

# Reasons

Enables arm64 support using the updating tooling in cimg-shared and cimg-orb and arch checks for the software included in this image

Test build: https://app.circleci.com/pipelines/github/CircleCI-Public/cimg-aws/42/workflows/f91a94dd-ddc5-453d-be12-1c4c653d9841/jobs/45

# Checklist

Please check through the following before opening your PR. Thank you!

- [ ] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
